### PR TITLE
Added PRIORITY test case and 21 error test cases

### DIFF
--- a/error/data-frame-padding.json
+++ b/error/data-frame-padding.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000400080000000104AAAAAA",
+    "frame": null,
+    "description": "data frame with invalid amount of padding"
+}

--- a/error/data-frame-stream.json
+++ b/error/data-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000001000000000000AA",
+    "frame": null,
+    "description": "data frame with invalid stream identifier"
+}

--- a/error/goaway-frame-size.json
+++ b/error/goaway-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "00000407000000000000000002",
+    "frame": null,
+    "description": "goaway frame of an invalid length"
+}

--- a/error/goaway-frame-stream.json
+++ b/error/goaway-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "0000080700000000010000000200000003",
+    "frame": null,
+    "description": "goaway frame with invalid stream identifier"
+}

--- a/error/headers-frame-padding.json
+++ b/error/headers-frame-padding.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000401080000000104AAAAAA",
+    "frame": null,
+    "description": "headers frame with invalid amount of padding"
+}

--- a/error/headers-frame-stream.json
+++ b/error/headers-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000001010000000000AA",
+    "frame": null,
+    "description": "headers frame with invalid stream identifier"
+}

--- a/error/ping-frame-size.json
+++ b/error/ping-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "000004060000000000AAAAAAAA",
+    "frame": null,
+    "description": "ping frame of an invalid length"
+}

--- a/error/ping-frame-stream.json
+++ b/error/ping-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000008060100000001AAAAAAAAAAAAAAAA",
+    "frame": null,
+    "description": "ping frame with invalid stream identifier"
+}

--- a/error/priority-frame-size.json
+++ b/error/priority-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "00000802000000000280000001FFAAAAAA",
+    "frame": null,
+    "description": "priority frame of an invalid length"
+}

--- a/error/priority-frame-stream.json
+++ b/error/priority-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000005020000000000AAAAAAAABB",
+    "frame": null,
+    "description": "priority frame with invalid stream identifier"
+}

--- a/error/push_promise-frame-padding.json
+++ b/error/push_promise-frame-padding.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000405080000000104AAAAAA",
+    "frame": null,
+    "description": "push_promise frame with invalid amount of padding"
+}

--- a/error/push_promise-frame-promised_stream-odd.json
+++ b/error/push_promise-frame-promised_stream-odd.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000405000000000100000001",
+    "frame": null,
+    "description": "push_promise frame with invalid (odd-numbered) promised stream identifier"
+}

--- a/error/push_promise-frame-promised_stream-zero.json
+++ b/error/push_promise-frame-promised_stream-zero.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000405000000000100000000",
+    "frame": null,
+    "description": "push_promise frame with invalid (zero) promised stream identifier"
+}

--- a/error/push_promise-frame-stream.json
+++ b/error/push_promise-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000405000000000077777777",
+    "frame": null,
+    "description": "push_promise frame with invalid stream identifier"
+}

--- a/error/rst_stream-frame-size.json
+++ b/error/rst_stream-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "000008030000000002AAAAAAAABBBBBBBB",
+    "frame": null,
+    "description": "rst_stream frame of an invalid length"
+}

--- a/error/rst_stream-frame-stream.json
+++ b/error/rst_stream-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000004030000000000AAAAAAAA",
+    "frame": null,
+    "description": "rst_stream frame with invalid stream identifier"
+}

--- a/error/settings-frame-ack-size.json
+++ b/error/settings-frame-ack-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "000006040100000000AAAABBBBBBBB",
+    "frame": null,
+    "description": "settings ack frame of an invalid length"
+}

--- a/error/settings-frame-size.json
+++ b/error/settings-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "000008040000000000AAAABBBBBBBBCCCC",
+    "frame": null,
+    "description": "settings frame of an invalid length"
+}

--- a/error/settings-frame-stream.json
+++ b/error/settings-frame-stream.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "000006040000000001AAAABBBBBBBB",
+    "frame": null,
+    "description": "settings frame with invalid stream identifier"
+}

--- a/error/window_update-frame-increment.json
+++ b/error/window_update-frame-increment.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        1
+    ],
+    "wire": "00000408000000000100000000",
+    "frame": null,
+    "description": "window_update frame with invalid window size increment"
+}

--- a/error/window_update-frame-size.json
+++ b/error/window_update-frame-size.json
@@ -1,0 +1,8 @@
+{
+    "error": [
+        6
+    ],
+    "wire": "0000020800000000015566",
+    "frame": null,
+    "description": "window_update frame of an invalid length"
+}

--- a/priority/normal.json
+++ b/priority/normal.json
@@ -1,0 +1,18 @@
+{
+    "error": null,
+    "wire": "0000050200000000090000000B07",
+    "frame": {
+        "length": 5,
+        "frame_payload": {
+            "stream_dependency": 11,
+            "weight": 8,
+            "exclusive": false,
+            "padding_length": null,
+            "padding": null
+        },
+        "flags": 0,
+        "stream_identifier": 9,
+        "type": 2
+    },
+    "description": "normal priority frame"
+}


### PR DESCRIPTION
This pull request adds a test case for a simple PRIORITY frame.

It also adds many invalid frame test cases. See below for the text in the standard that applies to each case.

`data-frame-padding.json`
`headers-frame-padding.json`
`push_promise-frame-padding.json`
If the length of the padding is the length of the frame payload or greater, the recipient MUST treat this as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`data-frame-stream.json`
If a DATA frame is received whose stream identifier field is 0x0, the recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`headers-frame-stream.json`
If a HEADERS frame is received whose stream identifier field is 0x0, the recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`priority-frame-stream.json`
If a PRIORITY frame is received with a stream identifier of 0x0, the recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`priority-frame-size.json`
A PRIORITY frame with a length other than 5 octets MUST be treated as a stream error (Section 5.4.2) of type FRAME_SIZE_ERROR.

`rst_stream-frame-stream.json`
If a RST_STREAM frame is received with a stream identifier of 0x0, the recipient MUST treat this as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`rst_stream-frame-size.json`
A RST_STREAM frame with a length other than 4 octets MUST be treated as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.

`settings-frame-stream.json`
If an endpoint receives a SETTINGS frame whose stream identifier field is anything other than 0x0, the endpoint MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`settings-frame-size.json`
A SETTINGS frame with a length other than a multiple of 6 octets MUST be treated as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.

`settings-frame-ack-size.json`
Receipt of a SETTINGS frame with the ACK flag set and a length field value other than 0 MUST be treated as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.

`push_promise-frame-stream.json`
If the stream identifier field specifies the value 0x0, a recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`push_promise-frame-promised_stream-zero.json`
A receiver MUST treat the receipt of a PUSH_PROMISE that promises an illegal stream identifier (Section 5.1.1) (that is, an identifier for a stream that is not currently in the "idle" state) as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`push_promise-frame-promised_stream-odd.json`
The promised stream identifier MUST be a valid choice for the next stream sent by the sender (see new stream identifier (Section 5.1.1)). **Note:** An odd-numbered stream is an invalid stream identifier for the server, and only the server can send PUSH_PROMISE frames.

`ping-frame-stream.json`
If a PING frame is received with a stream identifier field value other than 0x0, the recipient MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`ping-frame-size.json`
Receipt of a PING frame with a length field value other than 8 MUST be treated as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.

`goaway-frame-stream.json`
An endpoint MUST treat a GOAWAY frame with a stream identifier other than 0x0 as a connection error (Section 5.4.1) of type PROTOCOL_ERROR.

`goaway-frame-size.json`
An endpoint MUST send a FRAME_SIZE_ERROR error if a frame exceeds the size defined in SETTINGS_MAX_FRAME_SIZE, any limit defined for the frame type, or it is too small to contain mandatory frame data.

`window_update-frame-size.json`
A WINDOW_UPDATE frame with a length other than 4 octets MUST be treated as a connection error (Section 5.4.1) of type FRAME_SIZE_ERROR.

`window_update-frame-increment.json`
A receiver MUST treat the receipt of a WINDOW_UPDATE frame with an flow control window increment of 0 as a stream error (Section 5.4.2) of type PROTOCOL_ERROR
