### PR TITLE
Added END_HEADERS flags, printable characters and fixed PUSH_PROMISE stream ID

### DIFF
--- a/headers/normal.json
+++ b/headers/normal.json
@@ -4,9 +4,11 @@
     "frame": {
         "length": 1,
         "frame_payload": {
-            "priority": null,
+            "stream_dependency": null,
+            "weight": null,
             "header_block_fragment": "",
             "padding_length": null,
+            "exclusive": null,
             "padding": null
         },
         "flags": 0,

--- a/headers/normal.json
+++ b/headers/normal.json
@@ -1,17 +1,17 @@
 {
     "error": null,
-    "wire": "00000101000000000182",
+    "wire": "00000D010400000001746869732069732064756D6D79",
     "frame": {
-        "length": 1,
+        "length": 13,
         "frame_payload": {
             "stream_dependency": null,
             "weight": null,
-            "header_block_fragment": "",
+            "header_block_fragment": "this is dummy",
             "padding_length": null,
             "exclusive": null,
             "padding": null
         },
-        "flags": 0,
+        "flags": 4,
         "stream_identifier": 1,
         "type": 1
     },

--- a/headers/priority.json
+++ b/headers/priority.json
@@ -4,13 +4,11 @@
     "frame": {
         "length": 23,
         "frame_payload": {
-            "priority": {
-                "stream_dependency": 20,
-                "weight": 10,
-                "exclusive": true
-            },
+            "stream_dependency": 20,
+            "weight": 10,
             "header_block_fragment": "",
             "padding_length": 16,
+            "exclusive": true,
             "padding": "This is padding."
         },
         "flags": 40,

--- a/headers/priority.json
+++ b/headers/priority.json
@@ -1,17 +1,17 @@
 {
     "error": null,
-    "wire": "00001701280000000310800000140982546869732069732070616464696E672E",
+    "wire": "000023012C00000003108000001409746869732069732064756D6D79546869732069732070616464696E672E",
     "frame": {
-        "length": 23,
+        "length": 35,
         "frame_payload": {
             "stream_dependency": 20,
             "weight": 10,
-            "header_block_fragment": "",
+            "header_block_fragment": "this is dummy",
             "padding_length": 16,
             "exclusive": true,
             "padding": "This is padding."
         },
-        "flags": 40,
+        "flags": 44,
         "stream_identifier": 3,
         "type": 1
     },

--- a/push_promise/normal.json
+++ b/push_promise/normal.json
@@ -1,16 +1,16 @@
 {
     "error": null,
-    "wire": "000018050800000009060000000B746869732069732064756D6D79486F77647921",
+    "wire": "00001805080000000A060000000C746869732069732064756D6D79486F77647921",
     "frame": {
         "length": 24,
         "frame_payload": {
             "header_block_fragment": "this is dummy",
             "padding_length": 6,
-            "promised_stream_id": 11,
+            "promised_stream_id": 12,
             "padding": "Howdy!"
         },
         "flags": 8,
-        "stream_identifier": 9,
+        "stream_identifier": 10,
         "type": 5
     },
     "description": "normal push promise frame"

--- a/push_promise/normal.json
+++ b/push_promise/normal.json
@@ -1,6 +1,6 @@
 {
     "error": null,
-    "wire": "00001805080000000A060000000C746869732069732064756D6D79486F77647921",
+    "wire": "000018050C0000000A060000000C746869732069732064756D6D79486F77647921",
     "frame": {
         "length": 24,
         "frame_payload": {
@@ -9,7 +9,7 @@
             "promised_stream_id": 12,
             "padding": "Howdy!"
         },
-        "flags": 8,
+        "flags": 12,
         "stream_identifier": 10,
         "type": 5
     },


### PR DESCRIPTION
A few minor changes to existing frames:
- Replaced non-printable characters in header block fragment examples with regular ASCII so we don't depend on specific codepages or character encodings on the developer's machine.
- Added END_HEADERS flag because when decoding these frames in isolation that makes a bit more sense.
