### PR TITLE
PRIORITY: remove padding attributes

### DIFF
--- a/priority/normal.json
+++ b/priority/normal.json
@@ -6,9 +6,7 @@
         "frame_payload": {
             "stream_dependency": 11,
             "weight": 8,
-            "exclusive": false,
-            "padding_length": null,
-            "padding": null
+            "exclusive": false
         },
         "flags": 0,
         "stream_identifier": 9,


### PR DESCRIPTION
The PRIORITY frame does not have padding. This PR removes these attributes to avoid confusion.
Based on https://tools.ietf.org/html/rfc7540#section-6.3